### PR TITLE
Role to spin up undercloud VM with bridged networking on virt-host

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # ansible-undercloud
 Instantiate a TripleO undercloud relatively easily with Ansible
 
+## To do
+
+* virtualize 
+
 ## Diagram (WIP)
 
 ![basic diagram](http://i.imgur.com/5yXWjlw.png)

--- a/README.md
+++ b/README.md
@@ -1,9 +1,10 @@
 # ansible-undercloud
 Instantiate a TripleO undercloud relatively easily with Ansible
 
-## To do
+## Pre-requisites
 
-* virtualize 
+* Assumes a CentOS 7.3 host
+* External NIC must be configured with a bridge (with device name specified as `virt_host_bridge_devicename` in `vars/virt_host.yml`)
 
 ## Diagram (WIP)
 

--- a/roles/virt-host/tasks/main.yml
+++ b/roles/virt-host/tasks/main.yml
@@ -1,0 +1,112 @@
+---
+# based on: http://giovannitorres.me/create-a-linux-lab-on-kvm-using-cloud-images.html
+- name: Install deps
+  package:
+    name: genisoimage
+    state: present
+  with_items:
+    - genisoimage
+    - virt-install
+
+- name: See if disk exists
+  stat:
+    path: "{{ virt_working_directory }}/disk.{{ virt_image_name }}"
+  register: qcowdisk
+
+- name: Turn qcow image into disk
+  command: >
+    cp {{ virt_working_directory }}/{{ virt_image_name }} {{ virt_working_directory }}/disk.{{ virt_image_name }} 
+  when: not qcowdisk.stat.exists
+
+- name: Template cloud-config
+  template:
+    src: user-data.j2
+    dest: "{{ virt_working_directory }}/user-data"
+  register: template_user_data
+
+- name: Template meta-data
+  template:
+    src: meta-data.j2
+    dest: "{{ virt_working_directory }}/meta-data"
+  register: template_meta_data
+
+- name: Generate joliet ISO
+  command: >
+    genisoimage 
+      -o {{ virt_working_directory }}/user-data.iso 
+      -V cidata 
+      -r -J {{ virt_working_directory }}/user-data {{ virt_working_directory }}/meta-data
+  when: template_user_data.changed or template_meta_data.changed
+
+- name: Check if VM exists.
+  command: >
+    virsh list --all
+  register: vm_list
+
+
+- name: Perform virt install
+  command: >
+    virt-install 
+      --import 
+      --name {{ virt_host_hostname }}
+      --ram {{ virt_host_ram }}
+      --vcpus {{ virt_host_cpus }}
+      --disk {{ virt_working_directory }}/disk.{{ virt_image_name }},format=qcow2,bus=virtio
+      --disk {{ virt_working_directory }}/user-data.iso,device=cdrom
+      --network bridge=virbr0,model=virtio
+      --os-type=linux
+      --os-variant=rhel7
+      --noautoconsole
+  when: "'{{ virt_host_hostname }}' not in vm_list.stdout"
+
+# --network=network:host-network
+
+# [stack@rover ansible-undercloud]$ sudo virsh dumpxml undercloud_newton | grep -A5 -B2 br0
+# [stack@rover ansible-undercloud]$ sudo virsh dumpxml undercloud_newton | grep -B1 br0 | grep address
+# [stack@rover ansible-undercloud]$ sudo virsh dumpxml undercloud_newton | grep -B1 br0 | grep address | cut -d"'" -f2
+# 52:54:00:33:fe:bc
+# 52:54:00:2e:90:8f
+#  [stack@rover ansible-undercloud]$ sudo arp-scan --interface=br0 192.168.3.0/24 | awk '/52:54:00:33:fe:bc/ {print $1}'
+# 192.168.3.145
+# [stack@rover ansible-undercloud]$ sudo virsh net-dumpxml host-bridge                                             
+# <network connections='2'>
+#   <name>host-bridge</name>
+#   <uuid>9b4d0e10-6db4-4870-9730-7fae88202380</uuid>
+#   <forward mode='bridge'/>
+#   <bridge name='br0'/>
+# </network>
+# [stack@rover ansible-undercloud]$ sudo cat /root/bridge.xml
+# <network>
+#         <name>host-bridge</name>
+#         <forward mode="bridge"/>
+#         <bridge name="br0"/>
+# </network>
+
+
+
+## This only works for default natted schtuff.
+- name: Get MAC
+  shell: >
+    virsh dumpxml {{ virt_host_hostname }} | awk -F\' '/mac address/ {print $2}'
+  register: mac_address
+
+- name: Get IP
+  shell: >
+    grep -B1 "{{mac_address.stdout}}" /var/lib/libvirt/dnsmasq/{{ virt_host_bridge_name }}.status | head -n 1 | awk '{print $2}' | sed -e s/\"//g -e s/,//
+  register: get_ip
+
+# - name: Wait for a second for that mac to register
+#   pause:
+#     seconds: 5
+
+# - debug: "msg={{ get_ip }}"
+
+- name: Here is your IP, unreliably on the first run.
+  debug:
+    msg: "THe IP of the undercloud is: {{ get_ip.stdout }} "
+
+
+
+# genisoimage -output $CI_ISO -volid cidata -joliet -r $USER_DATA $META_DATA &>> $1.log
+
+# Do virt install

--- a/roles/virt-host/tasks/main.yml
+++ b/roles/virt-host/tasks/main.yml
@@ -3,6 +3,24 @@
 # -- Configures a virt-host and spins up undercloud VM --
 # -------------------------------------------------------
 # some pieces borrowed from: http://giovannitorres.me/create-a-linux-lab-on-kvm-using-cloud-images.html
+
+- name: Create the working directory
+  file:
+    path: "{{ virt_working_directory }}"
+    state: directory
+
+- name: Check if CentOS generic image exists
+  stat:
+    path: "{{ virt_working_directory }}/{{ virt_image_name }}"
+  register: generic_cloud_image
+
+# download the generic cloud image if it doesn't exist
+- name: Download the generic cloud image
+  get_url:
+    url: "{{ virt_generic_cloud_image }}"
+    dest: "{{ virt_working_directory }}"
+  when: not generic_cloud_image.stat.exists
+
 - name: Install deps
   package:
     name: genisoimage
@@ -64,10 +82,11 @@
 
 # end automate bridge creation ---------------------------------------
 
-- name: Force remove libvirt network
-  virt_net:
-    name: "{{ virt_host_bridge_name }}"
-    state: absent
+# @dougbtv: Sometimes I needed this when developing and changing this rapidly, it should be unnecessary in the future.
+# - name: Force remove libvirt network
+#   virt_net:
+#     name: "{{ virt_host_bridge_name }}"
+#     state: absent
 
 - name: Create libvirt network
   virt_net:
@@ -110,18 +129,7 @@
     arp-scan --interface=br0 {{ network_cidr }}/{{ network_cidr_netmask }} | awk '/{{mac_address.stdout}}/ {print $1}'
   register: get_ip
 
-# - name: Wait for a second for that mac to register
-#   pause:
-#     seconds: 5
-
-# - debug: "msg={{ get_ip }}"
-
 - name: Here is your IP, unreliably on the first run.
   debug:
     msg: "To SSH to the undercloud (on the first NIC found): ssh -i ~/.ssh/some_key centos@{{ get_ip.stdout }}"
 
-
-
-# genisoimage -output $CI_ISO -volid cidata -joliet -r $USER_DATA $META_DATA &>> $1.log
-
-# Do virt install

--- a/roles/virt-host/tasks/main.yml
+++ b/roles/virt-host/tasks/main.yml
@@ -1,5 +1,8 @@
 ---
-# based on: http://giovannitorres.me/create-a-linux-lab-on-kvm-using-cloud-images.html
+# -------------------------------------------------------
+# -- Configures a virt-host and spins up undercloud VM --
+# -------------------------------------------------------
+# some pieces borrowed from: http://giovannitorres.me/create-a-linux-lab-on-kvm-using-cloud-images.html
 - name: Install deps
   package:
     name: genisoimage
@@ -18,6 +21,9 @@
     cp {{ virt_working_directory }}/{{ virt_image_name }} {{ virt_working_directory }}/disk.{{ virt_image_name }} 
   when: not qcowdisk.stat.exists
 
+# !TODO: Add virt-resize
+# http://libguestfs.org/virt-resize.1.html
+
 - name: Template cloud-config
   template:
     src: user-data.j2
@@ -30,7 +36,7 @@
     dest: "{{ virt_working_directory }}/meta-data"
   register: template_meta_data
 
-- name: Generate joliet ISO
+- name: Generate joliet ISO of user-data
   command: >
     genisoimage 
       -o {{ virt_working_directory }}/user-data.iso 
@@ -38,11 +44,46 @@
       -r -J {{ virt_working_directory }}/user-data {{ virt_working_directory }}/meta-data
   when: template_user_data.changed or template_meta_data.changed
 
+# ---------------------------------------------------------------------
+# - !TODO: Automate bridge creation?
+# - @dougbtv: I put notes in the readme.
+# ---------------------------------------------------------------------
+
+# - name: Check for bridge
+#   shell: >
+#     nmcli con show | grep -P "^{{ virt_host_bridge_devicename }}\s"
+#   register: bridges_shown
+#   ignore_errors: true
+
+# - debug: "msg={{ bridges_shown }}"
+
+# - name: nmcli add bridge
+#   shell: >
+#     nmcli con add type bridge ifname {{ virt_host_bridge_devicename }}
+#   when: "bridges_shown.rc"
+
+# end automate bridge creation ---------------------------------------
+
+- name: Force remove libvirt network
+  virt_net:
+    name: "{{ virt_host_bridge_name }}"
+    state: absent
+
+- name: Create libvirt network
+  virt_net:
+    name: "{{ virt_host_bridge_name }}"
+    command: define
+    xml: '{{ lookup("template", "templates/bridge.xml.j2") }}'
+
+- name: Activate libvirt network
+  virt_net:
+    name: "{{ virt_host_bridge_name }}"
+    state: active
+
 - name: Check if VM exists.
   command: >
     virsh list --all
   register: vm_list
-
 
 - name: Perform virt install
   command: >
@@ -53,46 +94,20 @@
       --vcpus {{ virt_host_cpus }}
       --disk {{ virt_working_directory }}/disk.{{ virt_image_name }},format=qcow2,bus=virtio
       --disk {{ virt_working_directory }}/user-data.iso,device=cdrom
-      --network bridge=virbr0,model=virtio
+      --network network:{{ virt_host_bridge_name }},model=virtio
       --os-type=linux
       --os-variant=rhel7
       --noautoconsole
   when: "'{{ virt_host_hostname }}' not in vm_list.stdout"
 
-# --network=network:host-network
-
-# [stack@rover ansible-undercloud]$ sudo virsh dumpxml undercloud_newton | grep -A5 -B2 br0
-# [stack@rover ansible-undercloud]$ sudo virsh dumpxml undercloud_newton | grep -B1 br0 | grep address
-# [stack@rover ansible-undercloud]$ sudo virsh dumpxml undercloud_newton | grep -B1 br0 | grep address | cut -d"'" -f2
-# 52:54:00:33:fe:bc
-# 52:54:00:2e:90:8f
-#  [stack@rover ansible-undercloud]$ sudo arp-scan --interface=br0 192.168.3.0/24 | awk '/52:54:00:33:fe:bc/ {print $1}'
-# 192.168.3.145
-# [stack@rover ansible-undercloud]$ sudo virsh net-dumpxml host-bridge                                             
-# <network connections='2'>
-#   <name>host-bridge</name>
-#   <uuid>9b4d0e10-6db4-4870-9730-7fae88202380</uuid>
-#   <forward mode='bridge'/>
-#   <bridge name='br0'/>
-# </network>
-# [stack@rover ansible-undercloud]$ sudo cat /root/bridge.xml
-# <network>
-#         <name>host-bridge</name>
-#         <forward mode="bridge"/>
-#         <bridge name="br0"/>
-# </network>
-
-
-
-## This only works for default natted schtuff.
-- name: Get MAC
+- name: Get MAC (of first interface only)
   shell: >
-    virsh dumpxml {{ virt_host_hostname }} | awk -F\' '/mac address/ {print $2}'
+    virsh dumpxml {{ virt_host_hostname }} | grep -B1 br0 | grep address | cut -d"'" -f2 | head -n1
   register: mac_address
 
-- name: Get IP
+- name: Get IP (of first interface)
   shell: >
-    grep -B1 "{{mac_address.stdout}}" /var/lib/libvirt/dnsmasq/{{ virt_host_bridge_name }}.status | head -n 1 | awk '{print $2}' | sed -e s/\"//g -e s/,//
+    arp-scan --interface=br0 {{ network_cidr }}/{{ network_cidr_netmask }} | awk '/{{mac_address.stdout}}/ {print $1}'
   register: get_ip
 
 # - name: Wait for a second for that mac to register
@@ -103,7 +118,7 @@
 
 - name: Here is your IP, unreliably on the first run.
   debug:
-    msg: "THe IP of the undercloud is: {{ get_ip.stdout }} "
+    msg: "To SSH to the undercloud (on the first NIC found): ssh -i ~/.ssh/some_key centos@{{ get_ip.stdout }}"
 
 
 

--- a/roles/virt-host/templates/bridge.xml.j2
+++ b/roles/virt-host/templates/bridge.xml.j2
@@ -1,0 +1,5 @@
+<network>
+  <name>{{ virt_host_bridge_name }}</name>
+  <forward mode="bridge"/>
+  <bridge name="{{ virt_host_bridge_devicename }}"/>
+</network>

--- a/roles/virt-host/templates/meta-data.j2
+++ b/roles/virt-host/templates/meta-data.j2
@@ -1,0 +1,1 @@
+instance-id: {{ virt_host_hostname }}; local-hostname: {{ virt_host_hostname }}

--- a/roles/virt-host/templates/user-data.j2
+++ b/roles/virt-host/templates/user-data.j2
@@ -1,0 +1,24 @@
+#cloud-config
+
+# Hostname management
+preserve_hostname: False
+hostname: {{ virt_host_hostname }}
+fqdn: {{ virt_host_fqdn }}
+
+# Remove cloud-init when finished with it 
+runcmd:
+  - [ yum, -y, remove, cloud-init ]
+
+# Configure where output will go
+output: 
+  all: ">> /var/log/cloud-init.log"
+
+# configure interaction with ssh server  
+ssh_svcname: ssh
+ssh_deletekeys: True
+ssh_genkeytypes: ['rsa', 'ecdsa']
+
+# Install my public ssh key to the first user-defined user configured 
+# in cloud.cfg in the template (which is centos for CentOS cloud images)
+ssh_authorized_keys:
+  - {{ undercloud_pub_key }}

--- a/site.yml
+++ b/site.yml
@@ -2,6 +2,7 @@
 - hosts: virt-host
   vars_files:
     - vars/virt_host.yml
+    - vars/network.yml
 
   tasks:
     # create a working directory

--- a/site.yml
+++ b/site.yml
@@ -21,7 +21,8 @@
         url: "{{ virt_generic_cloud_image }}"
         dest: "{{ virt_working_directory }}"
       when: not generic_cloud_image.stat.exists
-
+  roles:
+    - { role: virt-host }
     # will need to create vars file for bridge names and IP ranges
 
     # check for bridge network (libvirt)
@@ -31,7 +32,6 @@
     # instantiate the vm with the virt commands
 
     # add virtual machine to inventory (undercloud)
-
 
 - hosts: undercloud
   vars_files:

--- a/site.yml
+++ b/site.yml
@@ -3,25 +3,7 @@
   vars_files:
     - vars/virt_host.yml
     - vars/network.yml
-
-  tasks:
-    # create a working directory
-    - name: Create the working directory
-      file:
-        path: "{{ virt_working_directory }}"
-        state: directory
-
-    - name: Check if CentOS generic image exists
-      stat:
-        path: "{{ virt_working_directory }}/{{ virt_image_name }}"
-      register: generic_cloud_image
-
-    # download the generic cloud image if it doesn't exist
-    - name: Download the generic cloud image
-      get_url:
-        url: "{{ virt_generic_cloud_image }}"
-        dest: "{{ virt_working_directory }}"
-      when: not generic_cloud_image.stat.exists
+  tasks: []
   roles:
     - { role: virt-host }
     # will need to create vars file for bridge names and IP ranges

--- a/vars/virt_host.yml
+++ b/vars/virt_host.yml
@@ -3,8 +3,9 @@ virt_generic_cloud_image: http://cloud.centos.org/centos/7/images/CentOS-7-x86_6
 virt_image_name: "{{ virt_generic_cloud_image.split('/')[-1] }}"
 virt_working_directory: /home/doug/Downloads
 virt_host_hostname: foober
-virt_host_fqdn: foobur
+virt_host_fqdn: foober.local
 virt_host_ram: 2048
 virt_host_cpus: 2
-virt_host_bridge_name: virbr0
+virt_host_bridge_name: hostbridge
+virt_host_bridge_devicename: br0
 undercloud_pub_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCj7K+U5FX9fSb0QeAbUH72SBKQUMBQgoZGbG/TPg9IVMjc1iMso61a6KPaF70RkPRBq3wUuOlQK70zjKyqK/H9dFe4YfPQQo2PcVKTphtx6MRu0ADuUkcFYVCkl8nqUF2slC4CVy8Gqo4ev6yXfs8U2hafUaItugAT6lG4ApSGN1LglbxsP3Qm339hv+CepEtrFKvktJePUEdAglTl3tDLynCSdGhYVmdMPGY1Oc6kdkQMkygyCH6+3eB662v2Qs9gAUHCVdsQ6IjOc8gW/2QG+02OBlHf1i3QjridyU7vDvQbkeL+mxllkbnnGVy8/9tl7jWneJ2zi0YJkge9IhDv doug@yoda"

--- a/vars/virt_host.yml
+++ b/vars/virt_host.yml
@@ -1,4 +1,10 @@
 ---
 virt_generic_cloud_image: http://cloud.centos.org/centos/7/images/CentOS-7-x86_64-GenericCloud.qcow2
 virt_image_name: "{{ virt_generic_cloud_image.split('/')[-1] }}"
-virt_working_directory: /root/undercloud_working_dir
+virt_working_directory: /home/doug/Downloads
+virt_host_hostname: foober
+virt_host_fqdn: foobur
+virt_host_ram: 2048
+virt_host_cpus: 2
+virt_host_bridge_name: virbr0
+undercloud_pub_key: "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQCj7K+U5FX9fSb0QeAbUH72SBKQUMBQgoZGbG/TPg9IVMjc1iMso61a6KPaF70RkPRBq3wUuOlQK70zjKyqK/H9dFe4YfPQQo2PcVKTphtx6MRu0ADuUkcFYVCkl8nqUF2slC4CVy8Gqo4ev6yXfs8U2hafUaItugAT6lG4ApSGN1LglbxsP3Qm339hv+CepEtrFKvktJePUEdAglTl3tDLynCSdGhYVmdMPGY1Oc6kdkQMkygyCH6+3eB662v2Qs9gAUHCVdsQ6IjOc8gW/2QG+02OBlHf1i3QjridyU7vDvQbkeL+mxllkbnnGVy8/9tl7jWneJ2zi0YJkge9IhDv doug@yoda"


### PR DESCRIPTION
Looks like I have this together. The only thing that's manually necessary is to setup your own `br0` that bridges where you want on the virt-host, I stubbed a note about this in the readme.

Things that are still necessary:

- [ ] dynamically add undercloud to inventory
- [ ] someday: automatically provision bridge
